### PR TITLE
Rake task outdoor alert

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
+  rescue_from JSON::ParserError, with: :resource_not_found
   layout :layout_by_resource
   helper_method :current_user
 
@@ -21,5 +22,10 @@ class ApplicationController < ActionController::Base
     else
       "application"
     end
+  end
+
+  def resource_not_found
+    flash[:alert] = 'Oops! Something went wrong!'
+    redirect_to airquality_path
   end
 end

--- a/app/controllers/outdoor_alerts_controller.rb
+++ b/app/controllers/outdoor_alerts_controller.rb
@@ -1,5 +1,6 @@
 class OutdoorAlertsController < ApplicationController
   before_action :find_outdoor_alert_objects, only: [:edit, :destroy]
+  # rescue_from Twilio::REST::RequestError, with: :twilio_bad_request
 
   def new
     @outdoor_alert = OutdoorAlert.new
@@ -65,4 +66,9 @@ class OutdoorAlertsController < ApplicationController
   def location_params
     params.require(:location).permit(:address)
   end
+
+  # def twilio_bad_request
+  #   flash[:alert] = 'The phone number you entered was not valid.'
+  #   redirect_to new_outdoor_alert_path
+  # end
 end

--- a/app/controllers/outdoor_alerts_controller.rb
+++ b/app/controllers/outdoor_alerts_controller.rb
@@ -68,7 +68,7 @@ class OutdoorAlertsController < ApplicationController
   end
 
   def twilio_bad_request
-    flash[:alert] = 'The phone number you entered was not valid.'
-    redirect_to new_outdoor_alert_path
+    flash[:alert] = 'The phone number you entered was not valid. Please delete alert.'
+    redirect_to alerts_path
   end
 end

--- a/app/controllers/outdoor_alerts_controller.rb
+++ b/app/controllers/outdoor_alerts_controller.rb
@@ -1,6 +1,6 @@
 class OutdoorAlertsController < ApplicationController
   before_action :find_outdoor_alert_objects, only: [:edit, :destroy]
-  # rescue_from Twilio::REST::RequestError, with: :twilio_bad_request
+  rescue_from Twilio::REST::RequestError, with: :twilio_bad_request
 
   def new
     @outdoor_alert = OutdoorAlert.new
@@ -67,8 +67,8 @@ class OutdoorAlertsController < ApplicationController
     params.require(:location).permit(:address)
   end
 
-  # def twilio_bad_request
-  #   flash[:alert] = 'The phone number you entered was not valid.'
-  #   redirect_to new_outdoor_alert_path
-  # end
+  def twilio_bad_request
+    flash[:alert] = 'The phone number you entered was not valid.'
+    redirect_to new_outdoor_alert_path
+  end
 end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -7,7 +7,7 @@ class Location < ActiveRecord::Base
   def address_must_be_supported_by_breezometer
     breezometer_service_errors = AirQuality.air_quality(self.address).error
     if breezometer_service_errors
-      errors.add(:address, "Location not supported, please try another location.")
+      errors.add(:location, "not supported, please try another location.")
     end
   end
 end

--- a/app/models/outdoor_alert.rb
+++ b/app/models/outdoor_alert.rb
@@ -14,14 +14,30 @@ class OutdoorAlert < ActiveRecord::Base
   validates :excellent, presence: true
 
   def initial_alert
-    @twilio_number = ENV['TWILIO_NUMBER']
     @client = Twilio::REST::Client.new ENV['TWILIO_ACCOUNT_SID'], ENV['TWILIO_AUTH_TOKEN']
     welcome = "Welcome to Air Alerts! You will receive air quality updates for #{self.location.address}."
     message = @client.account.messages.create(
-      :from => @twilio_number,
+      :from => ENV['TWILIO_NUMBER'],
       :to => "+#{self.phone.number}",
       :body => welcome
     )
     # puts message.to
+  end
+
+  def self.specific(quality)
+    self.where("outdoor_alerts.#{quality} = ?", 1)
+  end
+
+  def breezometer_reason
+    case self.reason
+    when "children"
+      :children
+    when "health"
+      :health
+    when "athlete"
+      :sport
+    else
+      :outside
+    end
   end
 end

--- a/app/models/outdoor_alert.rb
+++ b/app/models/outdoor_alert.rb
@@ -21,7 +21,7 @@ class OutdoorAlert < ActiveRecord::Base
       :to => "+#{self.phone.number}",
       :body => welcome
     )
-    # puts message.to
+    message.body
   end
 
   def self.specific(quality)

--- a/app/models/outdoor_alerter.rb
+++ b/app/models/outdoor_alerter.rb
@@ -1,0 +1,21 @@
+class OutdoorAlerter
+  def self.alert
+    Location.all.each do |location|
+      binding.pry
+      air_quality = AirQuality.air_quality(location.address)
+      unless air_quality.errors
+        binding.pry
+        quality = air_quality.breezometer_description.split(" ").first.downcase
+        location.outdoor_alerts.where("outdoor_alerts.#{quality} = ?", 1).each do |alert|
+          @client = Twilio::REST::Client.new ENV['TWILIO_ACCOUNT_SID'], ENV['TWILIO_AUTH_TOKEN']
+          message = @client.account.messages.create(
+            :from => ENV['TWILIO_NUMBER'],
+            :to => "+#{alert.phone.number}",
+            :body => "Air Alert: Air quality for #{location} is #{air_quality.breezometer_aqi}" \
+                      "(#{quality}). #{air_quality.random_recommendations[alert.reason]}"
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/models/outdoor_alerter.rb
+++ b/app/models/outdoor_alerter.rb
@@ -1,21 +1,31 @@
 class OutdoorAlerter
   def self.alert
-    Location.all.each do |location|
-      binding.pry
+    all_twilio_messages = Location.all.map do |location|
       air_quality = AirQuality.air_quality(location.address)
       unless air_quality.errors
-        binding.pry
-        quality = air_quality.breezometer_description.split(" ").first.downcase
-        location.outdoor_alerts.where("outdoor_alerts.#{quality} = ?", 1).each do |alert|
-          @client = Twilio::REST::Client.new ENV['TWILIO_ACCOUNT_SID'], ENV['TWILIO_AUTH_TOKEN']
-          message = @client.account.messages.create(
-            :from => ENV['TWILIO_NUMBER'],
-            :to => "+#{alert.phone.number}",
-            :body => "Air Alert: Air quality for #{location} is #{air_quality.breezometer_aqi}" \
-                      "(#{quality}). #{air_quality.random_recommendations[alert.reason]}"
-          )
-        end
+        alert_people_for(location, air_quality)
       end
     end
+    all_twilio_messages.flatten
+  end
+
+  def self.alert_people_for(location, air_quality)
+    quality = air_quality.breezometer_description.split(" ").first.downcase
+    twilio_messages = location.outdoor_alerts.specific(quality).map do |alert|
+      twilio(alert, location, air_quality)
+    end
+  end
+
+  def self.twilio(alert, location, air_quality)
+    @client = Twilio::REST::Client.new ENV['TWILIO_ACCOUNT_SID'], ENV['TWILIO_AUTH_TOKEN']
+    message = @client.account.messages.create(
+      :from => ENV['TWILIO_NUMBER'],
+      :to => "+#{alert.phone.number}",
+      :body => "Air Alert: Air quality for #{location.address} is" \
+                " #{air_quality.breezometer_aqi}" \
+                " (#{air_quality.breezometer_description})." \
+                " #{air_quality.random_recommendations[alert.breezometer_reason]}"
+    )
+    message.body
   end
 end

--- a/app/models/phone.rb
+++ b/app/models/phone.rb
@@ -2,10 +2,33 @@ class Phone < ActiveRecord::Base
   has_many :outdoor_alerts
   before_validation :sanitize_phone
 
-  validates :number, presence: true, length: { in: 10..11 }
+  validates :number, presence: true, length: { in: 10..12 }
+  validate :proper_phone_number
 
   def sanitize_phone
     self.number = number.gsub(/[^0-9]/, '')
     self.number = "1" + number if number.length == 10
+  end
+
+  def proper_phone_number
+    binding.pry
+    unless self.valid_number?
+      errors.add(:phone, "number is not a valid, please try another number.")
+    end
+  end
+
+  def valid_number?
+    lookup_client = Twilio::REST::LookupsClient.new(ENV['TWILIO_ACCOUNT_SID'], ENV['TWILIO_AUTH_TOKEN'])
+    begin
+      response = lookup_client.phone_numbers.get("+#{self.number}")
+      response.phone_number
+      return true
+    rescue => e
+      if e.code == 20404
+        return false
+      else
+        raise e
+      end
+    end
   end
 end

--- a/app/models/phone.rb
+++ b/app/models/phone.rb
@@ -2,32 +2,34 @@ class Phone < ActiveRecord::Base
   has_many :outdoor_alerts
   before_validation :sanitize_phone
 
-  validates :number, presence: true, length: { in: 10..12 }
-  validate :proper_phone_number
+  validates :number, presence: true, length: { in: 10..11 }
+  # validate :proper_phone_number
 
   def sanitize_phone
     self.number = number.gsub(/[^0-9]/, '')
     self.number = "1" + number if number.length == 10
   end
 
-  def proper_phone_number
-    unless self.valid_number?
-      errors.add(:phone, "number is not a valid, please try another number.")
-    end
-  end
-
-  def valid_number?
-    lookup_client = Twilio::REST::LookupsClient.new(ENV['TWILIO_ACCOUNT_SID'], ENV['TWILIO_AUTH_TOKEN'])
-    begin
-      response = lookup_client.phone_numbers.get("+#{self.number}")
-      response.phone_number
-      return true
-    rescue => e
-      if e.code == 20404
-        return false
-      else
-        raise e
-      end
-    end
-  end
+  # This validation does not work with Twilio Test Credentials
+  
+  # def proper_phone_number
+  #   unless self.valid_number?
+  #     errors.add(:phone, "number is not a valid, please try another number.")
+  #   end
+  # end
+  #
+  # def valid_number?
+  #   lookup_client = Twilio::REST::LookupsClient.new(ENV['TWILIO_ACCOUNT_SID'], ENV['TWILIO_AUTH_TOKEN'])
+  #   begin
+  #     response = lookup_client.phone_numbers.get("+#{self.number}")
+  #     response.phone_number
+  #     return true
+  #   rescue => e
+  #     if e.code == 20404
+  #       return false
+  #     else
+  #       raise e
+  #     end
+  #   end
+  # end
 end

--- a/app/models/phone.rb
+++ b/app/models/phone.rb
@@ -11,7 +11,6 @@ class Phone < ActiveRecord::Base
   end
 
   def proper_phone_number
-    binding.pry
     unless self.valid_number?
       errors.add(:phone, "number is not a valid, please try another number.")
     end

--- a/lib/tasks/alerts.rake
+++ b/lib/tasks/alerts.rake
@@ -1,0 +1,6 @@
+namespace :air do
+  desc "Alert all the peoples."
+  task :alerts => :environment do
+    OutdoorAlerter.alert
+  end
+end

--- a/lib/tasks/fancy.rake
+++ b/lib/tasks/fancy.rake
@@ -1,3 +1,0 @@
-task :fancy => :environment do
-  FancyRakeTaskDriverThing.new.perform
-end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -29,6 +29,14 @@ FactoryGirl.define do
     moderate 0
     low [0,1].sample
     poor 1
+
+    factory :outdoor_alert_all_levels do
+      excellent 1
+      fair 1
+      moderate 1
+      low 1
+      poor 1
+    end
   end
 
   factory :location do

--- a/spec/features/authenticated_user_can_search_for_air_quality_by_locations_spec.rb
+++ b/spec/features/authenticated_user_can_search_for_air_quality_by_locations_spec.rb
@@ -20,9 +20,9 @@ RSpec.feature "AuthenticatedUserCanSearchForAirQualityByLocations", type: :featu
         expect(current_path).to eq(airquality_path)
         within('.air-quality-box') do
           expect(page).to have_content("Air Quality for Beijing")
-          expect(page).to have_content("8")
-          expect(page).to have_content("Poor Air Quality")
-          expect(page).to have_content("Dominant Pollutant: Fine particulate matter (<2.5µm)")
+          expect(page).to have_content("30")
+          expect(page).to have_content("Low Air Quality")
+          expect(page).to have_content("Dominant Pollutant: Inhalable particulate matter (<10µm)")
         end
       end
     end

--- a/spec/features/authenticated_user_can_see_air_quality_for_twitter_locations_spec.rb
+++ b/spec/features/authenticated_user_can_see_air_quality_for_twitter_locations_spec.rb
@@ -16,9 +16,9 @@ RSpec.feature "AuthenticatedUserCanSeeAirQualityForTwitterLocations", type: :fea
 
       within('.air-quality-box') do
         expect(page).to have_content("Air Quality for #{location}")
-        expect(page).to have_content("83")
-        expect(page).to have_content("Excellent Air Quality")
-        expect(page).to have_content("Dominant Pollutant: Nitrogen dioxide")
+        expect(page).to have_content("72")
+        expect(page).to have_content("Fair Air Quality")
+        expect(page).to have_content("Dominant Pollutant: Fine particulate matter (<2.5µm)")
       end
     end
   end

--- a/spec/features/authenticated_user_can_sign_up_for_outdoor_alerts_spec.rb
+++ b/spec/features/authenticated_user_can_sign_up_for_outdoor_alerts_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature "AuthenticatedUserCanSignUpForOutdoorAlerts", type: :feature do
     click_on "Create Outdoor Air Quality Alert"
     expect(current_path).to eq new_outdoor_alert_path
 
-    fill_in "Address", with: "Los Angeles"
+    fill_in "Address", with: "Denver, CO"
     fill_in "Number", with: ENV['VALID_PHONE']
     choose "Health"
     check "Low Air Quality"
@@ -27,7 +27,7 @@ RSpec.feature "AuthenticatedUserCanSignUpForOutdoorAlerts", type: :feature do
     VCR.use_cassette("breezometer_service#air_quality_check") do
       click_on "Alert Me!"
     end
-
+    
     expect(current_path).to eq alerts_path
 
     alert = OutdoorAlert.last

--- a/spec/features/authenticated_user_can_sign_up_for_outdoor_alerts_spec.rb
+++ b/spec/features/authenticated_user_can_sign_up_for_outdoor_alerts_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature "AuthenticatedUserCanSignUpForOutdoorAlerts", type: :feature do
     VCR.use_cassette("breezometer_service#air_quality_check") do
       click_on "Alert Me!"
     end
-    
+
     expect(current_path).to eq alerts_path
 
     alert = OutdoorAlert.last
@@ -40,5 +40,58 @@ RSpec.feature "AuthenticatedUserCanSignUpForOutdoorAlerts", type: :feature do
         expect(page).to have_content("x")
       end
     end
+  end
+
+  it "cannot sign up with invalid phone" do
+    visit root_path
+
+    VCR.use_cassette("breezometer_service#air_quality") do
+      click_on "Login with Twitter"
+
+      click_on "Manage Alerts"
+    end
+
+    expect(current_path).to eq alerts_path
+
+    click_on "Create Outdoor Air Quality Alert"
+    expect(current_path).to eq new_outdoor_alert_path
+
+    fill_in "Address", with: "Denver"
+    fill_in "Number", with: "303"
+    choose "Health"
+    check "Low Air Quality"
+
+    VCR.use_cassette("breezometer_service#air_quality_check_bad_phone") do
+      click_on "Alert Me!"
+    end
+
+    expect(page).to have_content("Phone number you entered needs checking!")
+  end
+
+  it "cannot sign up with invalid location" do
+    visit root_path
+
+    VCR.use_cassette("breezometer_service#air_quality") do
+      click_on "Login with Twitter"
+
+      click_on "Manage Alerts"
+    end
+
+    expect(current_path).to eq alerts_path
+
+    click_on "Create Outdoor Air Quality Alert"
+    expect(current_path).to eq new_outdoor_alert_path
+
+    fill_in "Address", with: "India"
+    fill_in "Number", with: ENV['VALID_PHONE']
+    choose "Health"
+    check "Low Air Quality"
+
+    VCR.use_cassette("breezometer_service#air_quality_check_bad_location") do
+      click_on "Alert Me!"
+    end
+
+    expect(page).to have_content("Location you entered needs checking!")
+    expect(page).to have_content("Location not supported, please try another location.")
   end
 end

--- a/spec/features/authenticated_user_can_update_outdoor_alerts_spec.rb
+++ b/spec/features/authenticated_user_can_update_outdoor_alerts_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature "AuthenticatedUserCanUpdateOutdoorAlerts", type: :feature do
 
     expect(current_path).to eq edit_outdoor_alert_path(id: alert.id)
 
-    fill_in "Address", with: "Los Angeles"
+    fill_in "Address", with: "Denver, CO"
     fill_in "Number", with: ENV['VALID_PHONE']
     choose "Health"
     check "Low Air Quality"
@@ -32,6 +32,6 @@ RSpec.feature "AuthenticatedUserCanUpdateOutdoorAlerts", type: :feature do
 
     alert = OutdoorAlert.last.reload
 
-    expect(alert.location.address).to eq "Los Angeles"
+    expect(alert.location.address).to eq "Denver, CO"
   end
 end

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -1,5 +1,17 @@
 require 'rails_helper'
 
 RSpec.describe Location, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it "should check the location through breezometer before saving to db" do
+    VCR.use_cassette("breezometer_service#create_location_boston") do
+      location = Location.new(address: "Boston, MA")
+      expect(location.valid?)
+    end
+  end
+
+  it "not valid if breezometer doesn't support location, return error" do
+    VCR.use_cassette("breezometer_service#unsupported_location") do
+      location = Location.new(address: "Mumbai")
+      refute(location.valid?)
+    end
+  end
 end

--- a/spec/models/outdoor_alert_spec.rb
+++ b/spec/models/outdoor_alert_spec.rb
@@ -1,5 +1,29 @@
 require 'rails_helper'
 
 RSpec.describe OutdoorAlert, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it "should return symbol for breezometer reason endpoint" do
+    VCR.use_cassette("breezometer_service#air_quality_boston_for_reason") do
+      outdoor_alert_children = create(:outdoor_alert, reason: "children")
+
+      expect(outdoor_alert_children.breezometer_reason).to eq :children
+    end
+
+    VCR.use_cassette("breezometer_service#air_quality_boston_for_reason") do
+      outdoor_alert_health = create(:outdoor_alert, reason: "health")
+
+      expect(outdoor_alert_health.breezometer_reason).to eq :health
+    end
+
+    VCR.use_cassette("breezometer_service#air_quality_boston_for_reason") do
+      outdoor_alert_athlete = create(:outdoor_alert, reason: "athlete")
+
+      expect(outdoor_alert_athlete.breezometer_reason).to eq :sport
+    end
+
+    VCR.use_cassette("breezometer_service#air_quality_boston_for_reason") do
+      outdoor_alert_general = create(:outdoor_alert, reason: "general")
+
+      expect(outdoor_alert_general.breezometer_reason).to eq :outside
+    end
+  end
 end

--- a/spec/models/outdoor_alerter_spec.rb
+++ b/spec/models/outdoor_alerter_spec.rb
@@ -1,5 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe OutdoorAlerter, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it "should return the messages sent through twilio" do
+    VCR.use_cassette("breezometer_service#air_quality_boston_for_alert") do
+      outdoor_alerts = create_list(:outdoor_alert_all_levels, 3)
+    end
+
+    VCR.use_cassette("breezometer_service#air_quality_alerter") do
+      alerts = OutdoorAlerter.alert
+      expect(alerts.length).to eq 3
+    end
+  end
 end

--- a/spec/models/outdoor_alerter_spec.rb
+++ b/spec/models/outdoor_alerter_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe OutdoorAlerter, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/phone_spec.rb
+++ b/spec/models/phone_spec.rb
@@ -1,5 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe Phone, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it "takes out non-number characters ans adds US country code if not provided" do
+    phone = Phone.create(number: "(999) 999-9999")
+
+    expect(phone.number).to eq "19999999999"
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe User, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
-end

--- a/spec/vcr/breezometer_service_air_quality.yml
+++ b/spec/vcr/breezometer_service_air_quality.yml
@@ -25,29 +25,31 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 03 Mar 2016 20:31:50 GMT
+      - Sun, 06 Mar 2016 02:37:50 GMT
       Server:
       - Google Frontend
       Content-Length:
-      - '1245'
+      - '1336'
     body:
       encoding: UTF-8
-      string: '{"country_name": "United States", "breezometer_aqi": 83, "breezometer_color":
-        "#4AB936", "breezometer_description": "Excellent Air Quality", "country_aqi":
-        19, "country_aqi_prefix": "", "country_color": "#00E400", "country_description":
+      string: '{"country_name": "United States", "breezometer_aqi": 72, "breezometer_color":
+        "#7BCB33", "breezometer_description": "Fair Air Quality", "country_aqi": 33,
+        "country_aqi_prefix": "", "country_color": "#00E400", "country_description":
         "Good air quality", "data_valid": true, "key_valid": true, "random_recommendations":
-        {"children": "Hip Hip, Hooray! What a wonderful atmosphere for kids! Don''t
-        wait at home with them another minute!", "sport": "This is an excellent opportunity
-        to enjoy your favorite outdoor activity without any worries", "health": "This
-        air quality is excellent for people with respiratory sensitivities", "inside":
-        "Ventilate the house with the great air outside", "outside": "It''s an ideal
-        time to go outside and enjoy the fresh air"}, "dominant_pollutant_canonical_name":
-        "no2", "dominant_pollutant_description": "Nitrogen dioxide", "dominant_pollutant_text":
-        {"main": "The dominant pollutant is nitrogen dioxide (NO\u2082).", "effects":
-        "Exposure may cause increased bronchial reactivity in patients with asthma,
-        lung function decline in patients with COPD and increased risk of respiratory
-        infections, especially in young children", "causes": "Main sources are fuel
-        burning processes in industry and transportation."}}'
+        {"children": "Have fun with the kids outside, but stay alert for our notifications",
+        "sport": "You can go on a run - just keep your nose open for any changes!",
+        "health": "There is no real danger for people with health sensitivities. Just
+        keep an eye out for changes in air quality for the next few hours", "inside":
+        "The air quality is still good - we''ll keep you updated if things get worse",
+        "outside": "It''s still OK to go out and enjoy a stroll, just pay attention
+        for changes in air quality"}, "dominant_pollutant_canonical_name": "pm2.5",
+        "dominant_pollutant_description": "Fine particulate matter (<2.5\u00b5m)",
+        "dominant_pollutant_text": {"main": "The dominant pollutant is fine particulate
+        matter (PM2.5).", "effects": "Particles enter the lungs and cause local and
+        systemic inflammation in the respiratory system & heart, thus cause cardiovascular
+        and respiratory diseases such as asthma and bronchitis.", "causes": "Main
+        sources are fuel burning processes in industry, transportation and indoor
+        heating."}}'
     http_version: 
-  recorded_at: Thu, 03 Mar 2016 20:31:50 GMT
+  recorded_at: Sun, 06 Mar 2016 02:37:50 GMT
 recorded_with: VCR 3.0.1

--- a/spec/vcr/breezometer_service_air_quality_alerter.yml
+++ b/spec/vcr/breezometer_service_air_quality_alerter.yml
@@ -1,0 +1,358 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://api.breezometer.com/baqi?key=d30efaaa5b744a0b820fd3cd81c35c28&location=Boston,%2BMA
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 06 Mar 2016 19:26:28 GMT
+      Server:
+      - Google Frontend
+      Content-Length:
+      - '1410'
+    body:
+      encoding: UTF-8
+      string: '{"country_name": "United States", "breezometer_aqi": 69, "breezometer_color":
+        "#8AD130", "breezometer_description": "Fair Air Quality", "country_aqi": 37,
+        "country_aqi_prefix": "", "country_color": "#00E400", "country_description":
+        "Good air quality", "data_valid": true, "key_valid": true, "random_recommendations":
+        {"children": "You should supervise your children in the coming hours and monitor
+        changes in air quality", "sport": "You can go on a run - just keep your nose
+        open for any changes!", "health": "Exposure to air hazards is dangerous for
+        people with health sensitivities, so it is important to monitor air quality
+        at this time", "inside": "The amount of pollutants in the air is noticeable,
+        but still there is no danger to health - It is recommended to watch for changes",
+        "outside": "It''s still OK to go out and enjoy a stroll, just pay attention
+        for changes in air quality"}, "dominant_pollutant_canonical_name": "pm2.5",
+        "dominant_pollutant_description": "Fine particulate matter (<2.5\u00b5m)",
+        "dominant_pollutant_text": {"main": "The dominant pollutant is fine particulate
+        matter (PM2.5).", "effects": "Particles enter the lungs and cause local and
+        systemic inflammation in the respiratory system & heart, thus cause cardiovascular
+        and respiratory diseases such as asthma and bronchitis.", "causes": "Main
+        sources are fuel burning processes in industry, transportation and indoor
+        heating."}}'
+    http_version: 
+  recorded_at: Sun, 06 Mar 2016 19:26:28 GMT
+- request:
+    method: post
+    uri: https://ACacbd98a93f543d9650fd723bc9141cf5:4532a2b33e08e7db1b8c126073245b88@api.twilio.com/2010-04-01/Accounts/ACacbd98a93f543d9650fd723bc9141cf5/Messages.json
+    body:
+      encoding: US-ASCII
+      string: From=%2B15005550006&To=%2B13039315611&Body=Air+Alert%3A+Air+quality+for+Boston%2C+MA+is+69+%28Fair+Air+Quality%29.+It%27s+still+OK+to+go+out+and+enjoy+a+stroll%2C+just+pay+attention+for+changes+in+air+quality
+    headers:
+      Accept:
+      - application/json
+      Accept-Charset:
+      - utf-8
+      User-Agent:
+      - twilio-ruby/4.11.1 (ruby/x86_64-darwin14 2.2.3-p173)
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - Accept, Authorization, Content-Type, If-Match, If-Modified-Since, If-None-Match,
+        If-Unmodified-Since
+      Access-Control-Allow-Methods:
+      - GET, POST, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - ETag
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 06 Mar 2016 19:26:29 GMT
+      Strict-Transport-Security:
+      - max-age=15768000
+      Twilio-Request-Duration:
+      - '0.071'
+      Twilio-Request-Id:
+      - RQ384d040e35534aabadfed68caae51d4d
+      X-Powered-By:
+      - AT-5000
+      X-Shenanigans:
+      - none
+      Content-Length:
+      - '912'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"sid": "SM01ff58f9a76949228cda65b0f6a7c61c", "date_created": "Sun,
+        06 Mar 2016 19:26:29 +0000", "date_updated": "Sun, 06 Mar 2016 19:26:29 +0000",
+        "date_sent": null, "account_sid": "ACacbd98a93f543d9650fd723bc9141cf5", "to":
+        "+13039315611", "from": "+15005550006", "messaging_service_sid": null, "body":
+        "Sent from your Twilio trial account - Air Alert: Air quality for Boston,
+        MA is 69 (Fair Air Quality). It''s still OK to go out and enjoy a stroll,
+        just pay attention for changes in air quality", "status": "queued", "num_segments":
+        "1", "num_media": "0", "direction": "outbound-api", "api_version": "2010-04-01",
+        "price": null, "price_unit": "USD", "uri": "/2010-04-01/Accounts/ACacbd98a93f543d9650fd723bc9141cf5/Messages/SM01ff58f9a76949228cda65b0f6a7c61c.json",
+        "subresource_uris": {"media": "/2010-04-01/Accounts/ACacbd98a93f543d9650fd723bc9141cf5/Messages/SM01ff58f9a76949228cda65b0f6a7c61c/Media.json"}}'
+    http_version: 
+  recorded_at: Sun, 06 Mar 2016 19:26:29 GMT
+- request:
+    method: get
+    uri: http://api.breezometer.com/baqi?key=d30efaaa5b744a0b820fd3cd81c35c28&location=Boston,%2BMA
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 06 Mar 2016 19:26:30 GMT
+      Server:
+      - Google Frontend
+      Content-Length:
+      - '1433'
+    body:
+      encoding: UTF-8
+      string: '{"country_name": "United States", "breezometer_aqi": 69, "breezometer_color":
+        "#8AD130", "breezometer_description": "Fair Air Quality", "country_aqi": 37,
+        "country_aqi_prefix": "", "country_color": "#00E400", "country_description":
+        "Good air quality", "data_valid": true, "key_valid": true, "random_recommendations":
+        {"children": "No reason to panic, but pay attention to changes in air quality
+        and any signals of breathing problems in your children", "sport": "You can
+        exercise outdoors - but make sure to stay alert to our notifications", "health":
+        "There is no real danger for people with health sensitivities. Just keep an
+        eye out for changes in air quality for the next few hours", "inside": "The
+        amount of pollutants in the air is noticeable, but still there is no danger
+        to health - It is recommended to watch for changes", "outside": "You can go
+        out, but please pay attention for changes in air quality"}, "dominant_pollutant_canonical_name":
+        "pm2.5", "dominant_pollutant_description": "Fine particulate matter (<2.5\u00b5m)",
+        "dominant_pollutant_text": {"main": "The dominant pollutant is fine particulate
+        matter (PM2.5).", "effects": "Particles enter the lungs and cause local and
+        systemic inflammation in the respiratory system & heart, thus cause cardiovascular
+        and respiratory diseases such as asthma and bronchitis.", "causes": "Main
+        sources are fuel burning processes in industry, transportation and indoor
+        heating."}}'
+    http_version: 
+  recorded_at: Sun, 06 Mar 2016 19:26:30 GMT
+- request:
+    method: post
+    uri: https://ACacbd98a93f543d9650fd723bc9141cf5:4532a2b33e08e7db1b8c126073245b88@api.twilio.com/2010-04-01/Accounts/ACacbd98a93f543d9650fd723bc9141cf5/Messages.json
+    body:
+      encoding: US-ASCII
+      string: From=%2B15005550006&To=%2B13039315611&Body=Air+Alert%3A+Air+quality+for+Boston%2C+MA+is+69+%28Fair+Air+Quality%29.+You+can+go+out%2C+but+please+pay+attention+for+changes+in+air+quality
+    headers:
+      Accept:
+      - application/json
+      Accept-Charset:
+      - utf-8
+      User-Agent:
+      - twilio-ruby/4.11.1 (ruby/x86_64-darwin14 2.2.3-p173)
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - Accept, Authorization, Content-Type, If-Match, If-Modified-Since, If-None-Match,
+        If-Unmodified-Since
+      Access-Control-Allow-Methods:
+      - GET, POST, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - ETag
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 06 Mar 2016 19:26:30 GMT
+      Strict-Transport-Security:
+      - max-age=15768000
+      Twilio-Request-Duration:
+      - '0.043'
+      Twilio-Request-Id:
+      - RQ6fe678195abe40909e48f51904c3b898
+      X-Powered-By:
+      - AT-5000
+      X-Shenanigans:
+      - none
+      Content-Length:
+      - '890'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"sid": "SMd8ee94c59e9045a5816f07f058a2dab8", "date_created": "Sun,
+        06 Mar 2016 19:26:30 +0000", "date_updated": "Sun, 06 Mar 2016 19:26:30 +0000",
+        "date_sent": null, "account_sid": "ACacbd98a93f543d9650fd723bc9141cf5", "to":
+        "+13039315611", "from": "+15005550006", "messaging_service_sid": null, "body":
+        "Sent from your Twilio trial account - Air Alert: Air quality for Boston,
+        MA is 69 (Fair Air Quality). You can go out, but please pay attention for
+        changes in air quality", "status": "queued", "num_segments": "1", "num_media":
+        "0", "direction": "outbound-api", "api_version": "2010-04-01", "price": null,
+        "price_unit": "USD", "uri": "/2010-04-01/Accounts/ACacbd98a93f543d9650fd723bc9141cf5/Messages/SMd8ee94c59e9045a5816f07f058a2dab8.json",
+        "subresource_uris": {"media": "/2010-04-01/Accounts/ACacbd98a93f543d9650fd723bc9141cf5/Messages/SMd8ee94c59e9045a5816f07f058a2dab8/Media.json"}}'
+    http_version: 
+  recorded_at: Sun, 06 Mar 2016 19:26:30 GMT
+- request:
+    method: get
+    uri: http://api.breezometer.com/baqi?key=d30efaaa5b744a0b820fd3cd81c35c28&location=Boston,%2BMA
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 06 Mar 2016 19:26:31 GMT
+      Server:
+      - Google Frontend
+      Content-Length:
+      - '1486'
+    body:
+      encoding: UTF-8
+      string: '{"country_name": "United States", "breezometer_aqi": 69, "breezometer_color":
+        "#8AD130", "breezometer_description": "Fair Air Quality", "country_aqi": 37,
+        "country_aqi_prefix": "", "country_color": "#00E400", "country_description":
+        "Good air quality", "data_valid": true, "key_valid": true, "random_recommendations":
+        {"children": "No reason to panic, but pay attention to changes in air quality
+        and any signals of breathing problems in your children", "sport": "Since we
+        inhale more air during sports, you should keep track of changes in air quality
+        for the next few hours", "health": "Exposure to air hazards is dangerous for
+        people with health sensitivities, so it is important to monitor air quality
+        at this time", "inside": "The amount of pollutants in the air is noticeable,
+        but still there is no danger to health - It is recommended to watch for changes",
+        "outside": "It''s still OK to go out and enjoy a stroll, just pay attention
+        for changes in air quality"}, "dominant_pollutant_canonical_name": "pm2.5",
+        "dominant_pollutant_description": "Fine particulate matter (<2.5\u00b5m)",
+        "dominant_pollutant_text": {"main": "The dominant pollutant is fine particulate
+        matter (PM2.5).", "effects": "Particles enter the lungs and cause local and
+        systemic inflammation in the respiratory system & heart, thus cause cardiovascular
+        and respiratory diseases such as asthma and bronchitis.", "causes": "Main
+        sources are fuel burning processes in industry, transportation and indoor
+        heating."}}'
+    http_version: 
+  recorded_at: Sun, 06 Mar 2016 19:26:31 GMT
+- request:
+    method: post
+    uri: https://ACacbd98a93f543d9650fd723bc9141cf5:4532a2b33e08e7db1b8c126073245b88@api.twilio.com/2010-04-01/Accounts/ACacbd98a93f543d9650fd723bc9141cf5/Messages.json
+    body:
+      encoding: US-ASCII
+      string: From=%2B15005550006&To=%2B13039315611&Body=Air+Alert%3A+Air+quality+for+Boston%2C+MA+is+69+%28Fair+Air+Quality%29.+It%27s+still+OK+to+go+out+and+enjoy+a+stroll%2C+just+pay+attention+for+changes+in+air+quality
+    headers:
+      Accept:
+      - application/json
+      Accept-Charset:
+      - utf-8
+      User-Agent:
+      - twilio-ruby/4.11.1 (ruby/x86_64-darwin14 2.2.3-p173)
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - Accept, Authorization, Content-Type, If-Match, If-Modified-Since, If-None-Match,
+        If-Unmodified-Since
+      Access-Control-Allow-Methods:
+      - GET, POST, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - ETag
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 06 Mar 2016 19:26:32 GMT
+      Strict-Transport-Security:
+      - max-age=15768000
+      Twilio-Request-Duration:
+      - '0.038'
+      Twilio-Request-Id:
+      - RQeb81033dfa43403785237b2c954d04f6
+      X-Powered-By:
+      - AT-5000
+      X-Shenanigans:
+      - none
+      Content-Length:
+      - '912'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"sid": "SMd3eca5090439435a8482c2b85cb13802", "date_created": "Sun,
+        06 Mar 2016 19:26:31 +0000", "date_updated": "Sun, 06 Mar 2016 19:26:31 +0000",
+        "date_sent": null, "account_sid": "ACacbd98a93f543d9650fd723bc9141cf5", "to":
+        "+13039315611", "from": "+15005550006", "messaging_service_sid": null, "body":
+        "Sent from your Twilio trial account - Air Alert: Air quality for Boston,
+        MA is 69 (Fair Air Quality). It''s still OK to go out and enjoy a stroll,
+        just pay attention for changes in air quality", "status": "queued", "num_segments":
+        "1", "num_media": "0", "direction": "outbound-api", "api_version": "2010-04-01",
+        "price": null, "price_unit": "USD", "uri": "/2010-04-01/Accounts/ACacbd98a93f543d9650fd723bc9141cf5/Messages/SMd3eca5090439435a8482c2b85cb13802.json",
+        "subresource_uris": {"media": "/2010-04-01/Accounts/ACacbd98a93f543d9650fd723bc9141cf5/Messages/SMd3eca5090439435a8482c2b85cb13802/Media.json"}}'
+    http_version: 
+  recorded_at: Sun, 06 Mar 2016 19:26:32 GMT
+recorded_with: VCR 3.0.1

--- a/spec/vcr/breezometer_service_air_quality_boston.yml
+++ b/spec/vcr/breezometer_service_air_quality_boston.yml
@@ -25,22 +25,24 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 03 Mar 2016 21:48:14 GMT
+      - Sun, 06 Mar 2016 02:37:48 GMT
       Server:
       - Google Frontend
       Content-Length:
-      - '1257'
+      - '1432'
     body:
       encoding: UTF-8
-      string: '{"country_name": "United States", "breezometer_aqi": 80, "breezometer_color":
-        "#58BE35", "breezometer_description": "Excellent Air Quality", "country_aqi":
-        24, "country_aqi_prefix": "", "country_color": "#00E400", "country_description":
+      string: '{"country_name": "United States", "breezometer_aqi": 76, "breezometer_color":
+        "#69C534", "breezometer_description": "Fair Air Quality", "country_aqi": 28,
+        "country_aqi_prefix": "", "country_color": "#00E400", "country_description":
         "Good air quality", "data_valid": true, "key_valid": true, "random_recommendations":
-        {"children": "The air is ideal for outdoor activities with infants and children",
-        "sport": "This air quality is perfect for engaging in outdoor physical activities",
-        "health": "This air quality is excellent for people with respiratory sensitivities",
-        "inside": "Ventilate the house with the great air outside", "outside": "Hooray!
-        The air quality outside is awesome!"}, "dominant_pollutant_canonical_name":
+        {"children": "Have fun with the kids outside, but stay alert for our notifications",
+        "sport": "You can go on a run - just keep your nose open for any changes!",
+        "health": "Exposure to air hazards is dangerous for people with health sensitivities,
+        so it is important to monitor air quality at this time", "inside": "The amount
+        of pollutants in the air is noticeable, but still there is no danger to health
+        - It is recommended to watch for changes", "outside": "It''s still OK out
+        there. Just stay alert for notifications about change in air quality"}, "dominant_pollutant_canonical_name":
         "o3", "dominant_pollutant_description": "Ozone", "dominant_pollutant_text":
         {"main": "The dominant pollutant is ozone (O\u2083).", "effects": "Ozone can
         irritate the airways causing coughing, a burning sensation, wheezing and shortness
@@ -49,5 +51,5 @@ http_interactions:
         "causes": "Ozone is created in a chemical reaction between atmospheric oxygen,
         nitrogen oxides, organic compounds and sunlight."}}'
     http_version: 
-  recorded_at: Thu, 03 Mar 2016 21:48:14 GMT
+  recorded_at: Sun, 06 Mar 2016 02:37:48 GMT
 recorded_with: VCR 3.0.1

--- a/spec/vcr/breezometer_service_air_quality_boston_for_alert.yml
+++ b/spec/vcr/breezometer_service_air_quality_boston_for_alert.yml
@@ -1,0 +1,160 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://api.breezometer.com/baqi?key=d30efaaa5b744a0b820fd3cd81c35c28&location=Boston,%2BMA
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 06 Mar 2016 19:26:24 GMT
+      Server:
+      - Google Frontend
+      Content-Length:
+      - '1349'
+    body:
+      encoding: UTF-8
+      string: '{"country_name": "United States", "breezometer_aqi": 69, "breezometer_color":
+        "#8AD130", "breezometer_description": "Fair Air Quality", "country_aqi": 37,
+        "country_aqi_prefix": "", "country_color": "#00E400", "country_description":
+        "Good air quality", "data_valid": true, "key_valid": true, "random_recommendations":
+        {"children": "Have fun with the kids outside, but stay alert for our notifications",
+        "sport": "You can exercise outdoors - but make sure to stay alert to our notifications",
+        "health": "There is no real danger for people with health sensitivities. Just
+        keep an eye out for changes in air quality for the next few hours", "inside":
+        "The air quality is still good - we''ll keep you updated if things get worse",
+        "outside": "It''s still OK to go out and enjoy a stroll, just pay attention
+        for changes in air quality"}, "dominant_pollutant_canonical_name": "pm2.5",
+        "dominant_pollutant_description": "Fine particulate matter (<2.5\u00b5m)",
+        "dominant_pollutant_text": {"main": "The dominant pollutant is fine particulate
+        matter (PM2.5).", "effects": "Particles enter the lungs and cause local and
+        systemic inflammation in the respiratory system & heart, thus cause cardiovascular
+        and respiratory diseases such as asthma and bronchitis.", "causes": "Main
+        sources are fuel burning processes in industry, transportation and indoor
+        heating."}}'
+    http_version: 
+  recorded_at: Sun, 06 Mar 2016 19:26:25 GMT
+- request:
+    method: get
+    uri: http://api.breezometer.com/baqi?key=d30efaaa5b744a0b820fd3cd81c35c28&location=Boston,%2BMA
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 06 Mar 2016 19:26:26 GMT
+      Server:
+      - Google Frontend
+      Content-Length:
+      - '1345'
+    body:
+      encoding: UTF-8
+      string: '{"country_name": "United States", "breezometer_aqi": 69, "breezometer_color":
+        "#8AD130", "breezometer_description": "Fair Air Quality", "country_aqi": 37,
+        "country_aqi_prefix": "", "country_color": "#00E400", "country_description":
+        "Good air quality", "data_valid": true, "key_valid": true, "random_recommendations":
+        {"children": "Have fun with the kids outside, but stay alert for our notifications",
+        "sport": "You can go on a run - just keep your nose open for any changes!",
+        "health": "People with health sensitivities should monitor the air quality
+        in the next few hours", "inside": "The amount of pollutants in the air is
+        noticeable, but still there is no danger to health - It is recommended to
+        watch for changes", "outside": "It''s still OK to go out and enjoy a stroll,
+        just pay attention for changes in air quality"}, "dominant_pollutant_canonical_name":
+        "pm2.5", "dominant_pollutant_description": "Fine particulate matter (<2.5\u00b5m)",
+        "dominant_pollutant_text": {"main": "The dominant pollutant is fine particulate
+        matter (PM2.5).", "effects": "Particles enter the lungs and cause local and
+        systemic inflammation in the respiratory system & heart, thus cause cardiovascular
+        and respiratory diseases such as asthma and bronchitis.", "causes": "Main
+        sources are fuel burning processes in industry, transportation and indoor
+        heating."}}'
+    http_version: 
+  recorded_at: Sun, 06 Mar 2016 19:26:26 GMT
+- request:
+    method: get
+    uri: http://api.breezometer.com/baqi?key=d30efaaa5b744a0b820fd3cd81c35c28&location=Boston,%2BMA
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 06 Mar 2016 19:26:27 GMT
+      Server:
+      - Google Frontend
+      Content-Length:
+      - '1457'
+    body:
+      encoding: UTF-8
+      string: '{"country_name": "United States", "breezometer_aqi": 69, "breezometer_color":
+        "#8AD130", "breezometer_description": "Fair Air Quality", "country_aqi": 37,
+        "country_aqi_prefix": "", "country_color": "#00E400", "country_description":
+        "Good air quality", "data_valid": true, "key_valid": true, "random_recommendations":
+        {"children": "You should supervise your children in the coming hours and monitor
+        changes in air quality", "sport": "Since we inhale more air during sports,
+        you should keep track of changes in air quality for the next few hours", "health":
+        "Exposure to air hazards is dangerous for people with health sensitivities,
+        so it is important to monitor air quality at this time", "inside": "The amount
+        of pollutants in the air is noticeable, but still there is no danger to health
+        - It is recommended to watch for changes", "outside": "It''s still OK to go
+        out and enjoy a stroll, just pay attention for changes in air quality"}, "dominant_pollutant_canonical_name":
+        "pm2.5", "dominant_pollutant_description": "Fine particulate matter (<2.5\u00b5m)",
+        "dominant_pollutant_text": {"main": "The dominant pollutant is fine particulate
+        matter (PM2.5).", "effects": "Particles enter the lungs and cause local and
+        systemic inflammation in the respiratory system & heart, thus cause cardiovascular
+        and respiratory diseases such as asthma and bronchitis.", "causes": "Main
+        sources are fuel burning processes in industry, transportation and indoor
+        heating."}}'
+    http_version: 
+  recorded_at: Sun, 06 Mar 2016 19:26:27 GMT
+recorded_with: VCR 3.0.1

--- a/spec/vcr/breezometer_service_air_quality_boston_for_reason.yml
+++ b/spec/vcr/breezometer_service_air_quality_boston_for_reason.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://api.breezometer.com/baqi?key=d30efaaa5b744a0b820fd3cd81c35c28&location=Boston,%2BMA
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 06 Mar 2016 19:45:53 GMT
+      Server:
+      - Google Frontend
+      Content-Length:
+      - '1324'
+    body:
+      encoding: UTF-8
+      string: '{"country_name": "United States", "breezometer_aqi": 69, "breezometer_color":
+        "#8AD130", "breezometer_description": "Fair Air Quality", "country_aqi": 37,
+        "country_aqi_prefix": "", "country_color": "#00E400", "country_description":
+        "Good air quality", "data_valid": true, "key_valid": true, "random_recommendations":
+        {"children": "Have fun with the kids outside, but stay alert for our notifications",
+        "sport": "You can exercise outdoors - but make sure to stay alert to our notifications",
+        "health": "Exposure to air hazards is dangerous for people with health sensitivities,
+        so it is important to monitor air quality at this time", "inside": "The air
+        quality is still good - we''ll keep you updated if things get worse", "outside":
+        "You can go out, but please pay attention for changes in air quality"}, "dominant_pollutant_canonical_name":
+        "pm2.5", "dominant_pollutant_description": "Fine particulate matter (<2.5\u00b5m)",
+        "dominant_pollutant_text": {"main": "The dominant pollutant is fine particulate
+        matter (PM2.5).", "effects": "Particles enter the lungs and cause local and
+        systemic inflammation in the respiratory system & heart, thus cause cardiovascular
+        and respiratory diseases such as asthma and bronchitis.", "causes": "Main
+        sources are fuel burning processes in industry, transportation and indoor
+        heating."}}'
+    http_version: 
+  recorded_at: Sun, 06 Mar 2016 19:45:53 GMT
+recorded_with: VCR 3.0.1

--- a/spec/vcr/breezometer_service_air_quality_check.yml
+++ b/spec/vcr/breezometer_service_air_quality_check.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://api.breezometer.com/baqi?key=d30efaaa5b744a0b820fd3cd81c35c28&location=Los%2BAngeles
+    uri: http://api.breezometer.com/baqi?key=d30efaaa5b744a0b820fd3cd81c35c28&location=Denver,%2BCO
     body:
       encoding: US-ASCII
       string: ''
@@ -25,24 +25,25 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 03 Mar 2016 20:41:47 GMT
+      - Sun, 06 Mar 2016 02:37:53 GMT
       Server:
       - Google Frontend
       Content-Length:
-      - '1356'
+      - '1440'
     body:
       encoding: UTF-8
-      string: '{"country_name": "United States", "breezometer_aqi": 43, "breezometer_color":
-        "#FFD600", "breezometer_description": "Moderate Air Quality", "country_aqi":
-        90, "country_aqi_prefix": "", "country_color": "#FFFF00", "country_description":
-        "Moderate air quality", "data_valid": true, "key_valid": true, "random_recommendations":
-        {"children": "Pay attention to the respiratory status of your kid(s)", "sport":
-        "You should look for an alternative area with better air quality to work out",
+      string: '{"country_name": "United States", "breezometer_aqi": 72, "breezometer_color":
+        "#7BCB33", "breezometer_description": "Fair Air Quality", "country_aqi": 33,
+        "country_aqi_prefix": "", "country_color": "#00E400", "country_description":
+        "Good air quality", "data_valid": true, "key_valid": true, "random_recommendations":
+        {"children": "Have fun with the kids outside, but stay alert for our notifications",
+        "sport": "You can exercise outdoors - but make sure to stay alert to our notifications",
         "health": "There is no real danger for people with health sensitivities. Just
         keep an eye out for changes in air quality for the next few hours", "inside":
-        "We''re not going to tell you not to go outside, but you should continue tracking
-        the air quality around you", "outside": "The air quality outside isn''t the
-        best\u2026 try to find a cleaner area"}, "dominant_pollutant_canonical_name":
+        "The amount of pollutants in the air is noticeable, but still there is no
+        danger to your health - It is recommended to continue monitoring changes in
+        the coming hours", "outside": "It''s still OK to go out and enjoy a stroll,
+        just pay attention for changes in air quality"}, "dominant_pollutant_canonical_name":
         "pm2.5", "dominant_pollutant_description": "Fine particulate matter (<2.5\u00b5m)",
         "dominant_pollutant_text": {"main": "The dominant pollutant is fine particulate
         matter (PM2.5).", "effects": "Particles enter the lungs and cause local and
@@ -51,65 +52,13 @@ http_interactions:
         sources are fuel burning processes in industry, transportation and indoor
         heating."}}'
     http_version: 
-  recorded_at: Thu, 03 Mar 2016 20:41:47 GMT
-- request:
-    method: get
-    uri: http://api.breezometer.com/baqi?key=d30efaaa5b744a0b820fd3cd81c35c28&location=Los%2BAngeles
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v0.9.2
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Access-Control-Allow-Origin:
-      - "*"
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Thu, 03 Mar 2016 20:41:50 GMT
-      Server:
-      - Google Frontend
-      Content-Length:
-      - '1366'
-    body:
-      encoding: UTF-8
-      string: '{"country_name": "United States", "breezometer_aqi": 43, "breezometer_color":
-        "#FFD600", "breezometer_description": "Moderate Air Quality", "country_aqi":
-        90, "country_aqi_prefix": "", "country_color": "#FFFF00", "country_description":
-        "Moderate air quality", "data_valid": true, "key_valid": true, "random_recommendations":
-        {"children": "Pay attention to signs of respiratory distress in small children",
-        "sport": "You should look for an alternative area with better air quality
-        to work out", "health": "Exposure to air hazards is dangerous for people with
-        health sensitivities, so it is important to monitor air quality at this time",
-        "inside": "You don''t have to stay inside, but it''s recommended that you
-        keep tracking the air quality", "outside": "If you wish to stay outside for
-        a long time, you should try to find a cleaner place nearby"}, "dominant_pollutant_canonical_name":
-        "pm2.5", "dominant_pollutant_description": "Fine particulate matter (<2.5\u00b5m)",
-        "dominant_pollutant_text": {"main": "The dominant pollutant is fine particulate
-        matter (PM2.5).", "effects": "Particles enter the lungs and cause local and
-        systemic inflammation in the respiratory system & heart, thus cause cardiovascular
-        and respiratory diseases such as asthma and bronchitis.", "causes": "Main
-        sources are fuel burning processes in industry, transportation and indoor
-        heating."}}'
-    http_version: 
-  recorded_at: Thu, 03 Mar 2016 20:41:50 GMT
+  recorded_at: Sun, 06 Mar 2016 02:37:53 GMT
 - request:
     method: post
     uri: https://ACacbd98a93f543d9650fd723bc9141cf5:4532a2b33e08e7db1b8c126073245b88@api.twilio.com/2010-04-01/Accounts/ACacbd98a93f543d9650fd723bc9141cf5/Messages.json
     body:
       encoding: US-ASCII
-      string: From=%2B15005550006&To=%2B13039315611&Body=Welcome+to+Air+Alerts%21+You+will+receive+air+quality+updates+for+Los+Angeles.
+      string: From=%2B15005550006&To=%2B13039315611&Body=Welcome+to+Air+Alerts%21+You+will+receive+air+quality+updates+for+Denver%2C+CO.
     headers:
       Accept:
       - application/json
@@ -140,32 +89,32 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 03 Mar 2016 20:41:51 GMT
+      - Sun, 06 Mar 2016 02:37:54 GMT
       Strict-Transport-Security:
       - max-age=15768000
       Twilio-Request-Duration:
-      - '0.044'
+      - '0.037'
       Twilio-Request-Id:
-      - RQ857e805179a34738a1484a63f0404090
+      - RQ592ada4868fd458a81216d972d416158
       X-Powered-By:
       - AT-5000
       X-Shenanigans:
       - none
       Content-Length:
-      - '835'
+      - '834'
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"sid": "SM4fc5d58ed6204f73bc3e37a008a02413", "date_created": "Thu,
-        03 Mar 2016 20:41:51 +0000", "date_updated": "Thu, 03 Mar 2016 20:41:51 +0000",
+      string: '{"sid": "SM48b0858fc13745a790ef2f502cb2d4af", "date_created": "Sun,
+        06 Mar 2016 02:37:54 +0000", "date_updated": "Sun, 06 Mar 2016 02:37:54 +0000",
         "date_sent": null, "account_sid": "ACacbd98a93f543d9650fd723bc9141cf5", "to":
         "+13039315611", "from": "+15005550006", "messaging_service_sid": null, "body":
         "Sent from your Twilio trial account - Welcome to Air Alerts! You will receive
-        air quality updates for Los Angeles.", "status": "queued", "num_segments":
+        air quality updates for Denver, CO.", "status": "queued", "num_segments":
         "1", "num_media": "0", "direction": "outbound-api", "api_version": "2010-04-01",
-        "price": null, "price_unit": "USD", "uri": "/2010-04-01/Accounts/ACacbd98a93f543d9650fd723bc9141cf5/Messages/SM4fc5d58ed6204f73bc3e37a008a02413.json",
-        "subresource_uris": {"media": "/2010-04-01/Accounts/ACacbd98a93f543d9650fd723bc9141cf5/Messages/SM4fc5d58ed6204f73bc3e37a008a02413/Media.json"}}'
+        "price": null, "price_unit": "USD", "uri": "/2010-04-01/Accounts/ACacbd98a93f543d9650fd723bc9141cf5/Messages/SM48b0858fc13745a790ef2f502cb2d4af.json",
+        "subresource_uris": {"media": "/2010-04-01/Accounts/ACacbd98a93f543d9650fd723bc9141cf5/Messages/SM48b0858fc13745a790ef2f502cb2d4af/Media.json"}}'
     http_version: 
-  recorded_at: Thu, 03 Mar 2016 20:41:51 GMT
+  recorded_at: Sun, 06 Mar 2016 02:37:54 GMT
 recorded_with: VCR 3.0.1

--- a/spec/vcr/breezometer_service_air_quality_check_bad_location.yml
+++ b/spec/vcr/breezometer_service_air_quality_check_bad_location.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://api.breezometer.com/baqi?key=d30efaaa5b744a0b820fd3cd81c35c28&location=India
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 06 Mar 2016 19:55:51 GMT
+      Server:
+      - Google Frontend
+      Content-Length:
+      - '98'
+    body:
+      encoding: UTF-8
+      string: '{"data_valid": false, "error": {"message": "No data available for provided
+        location", "code": 21}}'
+    http_version: 
+  recorded_at: Sun, 06 Mar 2016 19:55:51 GMT
+recorded_with: VCR 3.0.1

--- a/spec/vcr/breezometer_service_air_quality_check_bad_phone.yml
+++ b/spec/vcr/breezometer_service_air_quality_check_bad_phone.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://api.breezometer.com/baqi?key=d30efaaa5b744a0b820fd3cd81c35c28&location=Denver
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 06 Mar 2016 19:53:12 GMT
+      Server:
+      - Google Frontend
+      Content-Length:
+      - '1289'
+    body:
+      encoding: UTF-8
+      string: '{"country_name": "United States", "breezometer_aqi": 68, "breezometer_color":
+        "#90D32D", "breezometer_description": "Fair Air Quality", "country_aqi": 38,
+        "country_aqi_prefix": "", "country_color": "#00E400", "country_description":
+        "Good air quality", "data_valid": true, "key_valid": true, "random_recommendations":
+        {"children": "Have fun with the kids outside, but stay alert for our notifications",
+        "sport": "You can go on a run - just keep your nose open for any changes!",
+        "health": "People with health sensitivities should monitor the air quality
+        in the next few hours", "inside": "The air quality is still good - we''ll
+        keep you updated if things get worse", "outside": "It''s still OK to go out
+        and enjoy a stroll, just pay attention for changes in air quality"}, "dominant_pollutant_canonical_name":
+        "pm2.5", "dominant_pollutant_description": "Fine particulate matter (<2.5\u00b5m)",
+        "dominant_pollutant_text": {"main": "The dominant pollutant is fine particulate
+        matter (PM2.5).", "effects": "Particles enter the lungs and cause local and
+        systemic inflammation in the respiratory system & heart, thus cause cardiovascular
+        and respiratory diseases such as asthma and bronchitis.", "causes": "Main
+        sources are fuel burning processes in industry, transportation and indoor
+        heating."}}'
+    http_version: 
+  recorded_at: Sun, 06 Mar 2016 19:53:12 GMT
+recorded_with: VCR 3.0.1

--- a/spec/vcr/breezometer_service_air_quality_check_update.yml
+++ b/spec/vcr/breezometer_service_air_quality_check_update.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://api.breezometer.com/baqi?key=d30efaaa5b744a0b820fd3cd81c35c28&location=Los%2BAngeles
+    uri: http://api.breezometer.com/baqi?key=d30efaaa5b744a0b820fd3cd81c35c28&location=Denver,%2BCO
     body:
       encoding: US-ASCII
       string: ''
@@ -25,76 +25,25 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 04 Mar 2016 04:11:06 GMT
+      - Sun, 06 Mar 2016 02:37:56 GMT
       Server:
       - Google Frontend
       Content-Length:
-      - '1412'
+      - '1448'
     body:
       encoding: UTF-8
-      string: '{"country_name": "United States", "breezometer_aqi": 47, "breezometer_color":
-        "#FFED00", "breezometer_description": "Moderate Air Quality", "country_aqi":
-        80, "country_aqi_prefix": "", "country_color": "#FFFF00", "country_description":
-        "Moderate air quality", "data_valid": true, "key_valid": true, "random_recommendations":
-        {"children": "You can go outside with the kids, but monitor their breathing
-        & pay attention to notifications", "sport": "You should look for an alternative
-        area with better air quality to work out", "health": "Exposure to air hazards
-        is dangerous for people with health sensitivities, so it is important to monitor
-        air quality at this time", "inside": "We''re not going to tell you not to
-        go outside, but you should continue tracking the air quality around you",
-        "outside": "If you wish to stay outside for a long time, you should try to
-        find a cleaner place nearby"}, "dominant_pollutant_canonical_name": "pm2.5",
-        "dominant_pollutant_description": "Fine particulate matter (<2.5\u00b5m)",
-        "dominant_pollutant_text": {"main": "The dominant pollutant is fine particulate
-        matter (PM2.5).", "effects": "Particles enter the lungs and cause local and
-        systemic inflammation in the respiratory system & heart, thus cause cardiovascular
-        and respiratory diseases such as asthma and bronchitis.", "causes": "Main
-        sources are fuel burning processes in industry, transportation and indoor
-        heating."}}'
-    http_version: 
-  recorded_at: Fri, 04 Mar 2016 04:11:06 GMT
-- request:
-    method: get
-    uri: http://api.breezometer.com/baqi?key=d30efaaa5b744a0b820fd3cd81c35c28&location=Los%2BAngeles
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v0.9.2
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Access-Control-Allow-Origin:
-      - "*"
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 04 Mar 2016 04:11:15 GMT
-      Server:
-      - Google Frontend
-      Content-Length:
-      - '1272'
-    body:
-      encoding: UTF-8
-      string: '{"country_name": "United States", "breezometer_aqi": 47, "breezometer_color":
-        "#FFED00", "breezometer_description": "Moderate Air Quality", "country_aqi":
-        80, "country_aqi_prefix": "", "country_color": "#FFFF00", "country_description":
-        "Moderate air quality", "data_valid": true, "key_valid": true, "random_recommendations":
-        {"children": "Pay attention to the respiratory status of your kid(s)", "sport":
-        "You want to work out now??!\u2026 Only if you have no plan B", "health":
-        "People with health sensitivities should be prepared for minor respiratory
-        difficulties", "inside": "There''s no need to get worried, but keep tracking
-        air quality in the next few hours", "outside": "The air quality outside isn''t
-        the best\u2026 try to find a cleaner area"}, "dominant_pollutant_canonical_name":
+      string: '{"country_name": "United States", "breezometer_aqi": 72, "breezometer_color":
+        "#7BCB33", "breezometer_description": "Fair Air Quality", "country_aqi": 33,
+        "country_aqi_prefix": "", "country_color": "#00E400", "country_description":
+        "Good air quality", "data_valid": true, "key_valid": true, "random_recommendations":
+        {"children": "You should supervise your children in the coming hours and monitor
+        changes in air quality", "sport": "You can go on a run - just keep your nose
+        open for any changes!", "health": "There is no real danger for people with
+        health sensitivities. Just keep an eye out for changes in air quality for
+        the next few hours", "inside": "The amount of pollutants in the air is noticeable,
+        but still there is no danger to your health - It is recommended to continue
+        monitoring changes in the coming hours", "outside": "It''s still OK to go
+        out and enjoy a stroll, just pay attention for changes in air quality"}, "dominant_pollutant_canonical_name":
         "pm2.5", "dominant_pollutant_description": "Fine particulate matter (<2.5\u00b5m)",
         "dominant_pollutant_text": {"main": "The dominant pollutant is fine particulate
         matter (PM2.5).", "effects": "Particles enter the lungs and cause local and
@@ -103,5 +52,5 @@ http_interactions:
         sources are fuel burning processes in industry, transportation and indoor
         heating."}}'
     http_version: 
-  recorded_at: Fri, 04 Mar 2016 04:11:15 GMT
+  recorded_at: Sun, 06 Mar 2016 02:37:56 GMT
 recorded_with: VCR 3.0.1

--- a/spec/vcr/breezometer_service_air_quality_search.yml
+++ b/spec/vcr/breezometer_service_air_quality_search.yml
@@ -25,30 +25,29 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 03 Mar 2016 20:31:52 GMT
+      - Sun, 06 Mar 2016 02:37:52 GMT
       Server:
       - Google Frontend
       Content-Length:
-      - '1266'
+      - '1227'
     body:
       encoding: UTF-8
-      string: '{"country_name": "China", "breezometer_aqi": 8, "breezometer_color":
-        "#E50000", "breezometer_description": "Poor Air Quality", "country_aqi": 346,
-        "country_aqi_prefix": "", "country_color": "#7E0023", "country_description":
-        "Severe air pollution", "data_valid": true, "key_valid": true, "random_recommendations":
-        {"children": "Children & infants should not be outside in these air conditions",
-        "sport": "We hope you have a treadmill at home\u2026 Don''t go outside for
-        any physical activity", "health": "This is the kind of poor air quality that
-        the doctors warned you about. Don''t go outside now", "inside": "What you
-        need to do ASAP is close the windows and activate the air conditioner", "outside":
-        "We have 3 words for you: Don''t go outside"}, "dominant_pollutant_canonical_name":
-        "pm2.5", "dominant_pollutant_description": "Fine particulate matter (<2.5\u00b5m)",
-        "dominant_pollutant_text": {"main": "The dominant pollutant is fine particulate
-        matter (PM2.5).", "effects": "Particles enter the lungs and cause local and
+      string: '{"country_name": "China", "breezometer_aqi": 30, "breezometer_color":
+        "#FF8C00", "breezometer_description": "Low Air Quality", "country_aqi": 123,
+        "country_aqi_prefix": "", "country_color": "#FF7E00", "country_description":
+        "Light air pollution", "data_valid": true, "key_valid": true, "random_recommendations":
+        {"children": "Keep calm and stay indoors. Do it for the kids\u2026", "sport":
+        "You don\u2019t want to do your workout in this environment. Find a cleaner
+        area", "health": "There is a strong chance for respiratory distress for those
+        with respiratory sensitivities", "inside": "It is a good idea to stay in closed
+        & air conditioned places", "outside": "You don''t have to stay inside but
+        try to find a cleaner place in the area"}, "dominant_pollutant_canonical_name":
+        "pm10", "dominant_pollutant_description": "Inhalable particulate matter (<10\u00b5m)",
+        "dominant_pollutant_text": {"main": "The dominant pollutant is inhalable particulate
+        matter (PM10).", "effects": "Particles enter the lungs and cause local and
         systemic inflammation in the respiratory system & heart, thus cause cardiovascular
         and respiratory diseases such as asthma and bronchitis.", "causes": "Main
-        sources are fuel burning processes in industry, transportation and indoor
-        heating."}}'
+        sources are natural dust, smoke and pollen."}}'
     http_version: 
-  recorded_at: Thu, 03 Mar 2016 20:31:52 GMT
+  recorded_at: Sun, 06 Mar 2016 02:37:52 GMT
 recorded_with: VCR 3.0.1

--- a/spec/vcr/breezometer_service_create_location_boston.yml
+++ b/spec/vcr/breezometer_service_create_location_boston.yml
@@ -1,0 +1,55 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://api.breezometer.com/baqi?key=d30efaaa5b744a0b820fd3cd81c35c28&location=Boston,%2BMA
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 06 Mar 2016 19:36:16 GMT
+      Server:
+      - Google Frontend
+      Content-Length:
+      - '1382'
+    body:
+      encoding: UTF-8
+      string: '{"country_name": "United States", "breezometer_aqi": 69, "breezometer_color":
+        "#8AD130", "breezometer_description": "Fair Air Quality", "country_aqi": 37,
+        "country_aqi_prefix": "", "country_color": "#00E400", "country_description":
+        "Good air quality", "data_valid": true, "key_valid": true, "random_recommendations":
+        {"children": "You should supervise your children in the coming hours and monitor
+        changes in air quality", "sport": "Since we inhale more air during sports,
+        you should keep track of changes in air quality for the next few hours", "health":
+        "There is no real danger for people with health sensitivities. Just keep an
+        eye out for changes in air quality for the next few hours", "inside": "The
+        air quality is still good - we''ll keep you updated if things get worse",
+        "outside": "You can go out, but please pay attention for changes in air quality"},
+        "dominant_pollutant_canonical_name": "pm2.5", "dominant_pollutant_description":
+        "Fine particulate matter (<2.5\u00b5m)", "dominant_pollutant_text": {"main":
+        "The dominant pollutant is fine particulate matter (PM2.5).", "effects": "Particles
+        enter the lungs and cause local and systemic inflammation in the respiratory
+        system & heart, thus cause cardiovascular and respiratory diseases such as
+        asthma and bronchitis.", "causes": "Main sources are fuel burning processes
+        in industry, transportation and indoor heating."}}'
+    http_version: 
+  recorded_at: Sun, 06 Mar 2016 19:36:16 GMT
+recorded_with: VCR 3.0.1

--- a/spec/vcr/breezometer_service_unsupported_location.yml
+++ b/spec/vcr/breezometer_service_unsupported_location.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://api.breezometer.com/baqi?key=d30efaaa5b744a0b820fd3cd81c35c28&location=Mumbai
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 06 Mar 2016 19:39:28 GMT
+      Server:
+      - Google Frontend
+      Content-Length:
+      - '92'
+    body:
+      encoding: UTF-8
+      string: '{"data_valid": false, "error": {"message": "Provided location is unsupported.",
+        "code": 20}}'
+    http_version: 
+  recorded_at: Sun, 06 Mar 2016 19:39:28 GMT
+recorded_with: VCR 3.0.1


### PR DESCRIPTION
Created a rake task to send out alerts for when the air quality is bad for a given location and a given level. Added model tests. Added Twilio Lookup API, however, it does not work in the test environment so it is commented out for now (which is bad, yes I know). Added a rescue from bad request from Breezometer API to the application controller, though is at this time unable to replicate this exact error for testing.

Connects to #20, connects to #21, connects to #16.