### PR TITLE
Api caching

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,10 @@ gem 'figaro'
 gem 'faraday'
 gem 'twilio-ruby'
 gem "skylight"
+gem 'memcachier'
+gem 'dalli'
+# gem 'api_cache'
+# gem 'moneta'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,6 +59,7 @@ GEM
     concurrent-ruby (1.0.1)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
+    dalli (2.7.6)
     database_cleaner (1.5.1)
     debug_inspector (0.0.2)
     diff-lcs (1.2.5)
@@ -91,6 +92,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
+    memcachier (0.0.2)
     metaclass (0.0.4)
     method_source (0.8.2)
     mime-types (2.99.1)
@@ -225,6 +227,7 @@ DEPENDENCIES
   byebug
   capybara
   coffee-rails (~> 4.1.0)
+  dalli
   database_cleaner
   factory_girl
   faraday
@@ -232,6 +235,7 @@ DEPENDENCIES
   jbuilder (~> 2.0)
   jquery-rails
   launchy
+  memcachier
   mocha
   omniauth-twitter
   pg (~> 0.15)

--- a/app/services/breezometer_service.rb
+++ b/app/services/breezometer_service.rb
@@ -9,7 +9,9 @@ class BreezometerService
   end
 
   def air_quality(location)
-    parse(connection.get("", {location: location, key: ENV["BREEZOMETER_KEY"]}))
+    Rails.cache.fetch("breezometer_air_#{location}", :expires => 15.minutes) do
+      parse(connection.get("", {location: location, key: ENV["BREEZOMETER_KEY"]}))
+    end
   end
 
   private

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -11,7 +11,7 @@ Rails.application.configure do
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
-  config.action_controller.perform_caching = false
+  config.action_controller.perform_caching = true
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -56,6 +56,7 @@ Rails.application.configure do
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
+  config.cache_store = :dalli_store
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'

--- a/spec/features/authenticated_user_can_see_air_quality_for_twitter_locations_spec.rb
+++ b/spec/features/authenticated_user_can_see_air_quality_for_twitter_locations_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature "AuthenticatedUserCanSeeAirQualityForTwitterLocations", type: :fea
         expect(page).to have_content("Air Quality for #{location}")
         expect(page).to have_content("72")
         expect(page).to have_content("Fair Air Quality")
-        expect(page).to have_content("Dominant Pollutant: Fine particulate matter (<2.5µm)")
+        expect(page).to have_content("Dominant Pollutant: Ozone")
       end
     end
   end


### PR DESCRIPTION
Cache the api calls made to breezometer. Takes a repeated call from 1.5-2 seconds down to about 30ms.

Connects to #25.